### PR TITLE
feat: Added support for custom tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ module "labels" {
   managedby   = var.managedby
   label_order = var.label_order
   repository  = var.repository
+  extra_tags = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "labels" {
   managedby   = var.managedby
   label_order = var.label_order
   repository  = var.repository
-  extra_tags = var.extra_tags
+  extra_tags  = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -179,3 +179,9 @@ variable "sku_name" {
   default     = "Standard"
   description = "The SKU which should be used. At this time the only supported value is Standard. Defaults to Standard."
 }
+variable "extra_tags" {
+type = map(string)
+default = null
+description = "Variable to pass extra tags."
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -35,9 +35,9 @@ variable "managedby" {
 }
 
 variable "extra_tags" {
-type = map(string)
-default = null
-description = "Variable to pass extra tags."
+  type        = map(string)
+  default     = null
+  description = "Variable to pass extra tags."
 }
 
 variable "enable" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "managedby" {
   description = "ManagedBy, eg 'CloudDrove'."
 }
 
+variable "extra_tags" {
+type = map(string)
+default = null
+description = "Variable to pass extra tags."
+}
+
 variable "enable" {
   type        = bool
   default     = true
@@ -179,9 +185,5 @@ variable "sku_name" {
   default     = "Standard"
   description = "The SKU which should be used. At this time the only supported value is Standard. Defaults to Standard."
 }
-variable "extra_tags" {
-type = map(string)
-default = null
-description = "Variable to pass extra tags."
-}
+
 


### PR DESCRIPTION
## what
- Add custom tags

## why
-  Azure Modules only support tags from module.labels.tags, we want that any user to pass their custom tags.

