### PR TITLE
fix: Updated attribute 'private_endpoint_network_policies'

### DIFF
--- a/.github/workflows/auto_assignee.yml
+++ b/.github/workflows/auto_assignee.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   assignee:
-    uses: clouddrove/github-shared-workflows/.github/workflows/auto_assignee.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/auto_assignee.yml@1.2.7
     secrets:
       GITHUB: ${{ secrets.GITHUB }}
     with:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   auto-merge:
-    uses: clouddrove/github-shared-workflows/.github/workflows/auto_merge.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/auto_merge.yml@1.2.7
     secrets:
       GITHUB: ${{ secrets.GITHUB }}
     with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   changelog:
-    uses: clouddrove/github-shared-workflows/.github/workflows/changelog.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/changelog.yml@1.2.7
     secrets: inherit
     with:
       branch: 'master'

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,21 +6,21 @@ on:
   workflow_dispatch:
 jobs:
   basic-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.7
     with:
       working_directory: './_example/basic/'
 
   complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.7
     with:
       working_directory: './_example/complete/'
 
   name-specific_subnet:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.7
     with:
       working_directory: './_example/name-specific_subnet/'
 
   nat-gateway_subnet:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.7
     with:
       working_directory: './_example/nat-gateway_subnet/'

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -6,6 +6,6 @@ on:
   workflow_dispatch:
 jobs:
   tf-lint:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@1.2.7
     secrets:
       GITHUB: ${{ secrets.GITHUB }}

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   tfsec:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tfsec.yml@1.2.5
+    uses: clouddrove/github-shared-workflows/.github/workflows/tfsec.yml@1.2.7
     secrets: inherit
     with:
       working_directory: '.'

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_subnet" "subnet" {
   service_endpoints                             = var.service_endpoints
   service_endpoint_policy_ids                   = var.service_endpoint_policy_ids
   private_link_service_network_policies_enabled = var.subnet_enforce_private_link_service_network_policies
-  private_endpoint_network_policies             = var.subnet_enforce_private_link_endpoint_network_policies
+  private_endpoint_network_policies             = var.private_endpoint_network_policies
 
   dynamic "delegation" {
     for_each = var.delegation

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_subnet" "subnet" {
   service_endpoints                             = var.service_endpoints
   service_endpoint_policy_ids                   = var.service_endpoint_policy_ids
   private_link_service_network_policies_enabled = var.subnet_enforce_private_link_service_network_policies
-  private_endpoint_network_policies_enabled     = var.subnet_enforce_private_link_endpoint_network_policies
+  private_endpoint_network_policies             = var.subnet_enforce_private_link_endpoint_network_policies
 
   dynamic "delegation" {
     for_each = var.delegation

--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "azurerm_route_table" "rt" {
   name                          = var.route_table_name == null ? format("%s-route-table", module.labels.id) : format("%s-%s-route-table", module.labels.id, var.route_table_name)
   location                      = var.location
   resource_group_name           = var.resource_group_name
-  disable_bgp_route_propagation = var.disable_bgp_route_propagation
+  bgp_route_propagation_enabled = var.bgp_route_propagation_enabled
   tags                          = module.labels.tags
 
   dynamic "route" {

--- a/variables.tf
+++ b/variables.tf
@@ -70,7 +70,7 @@ variable "subnet_names" {
   description = "A list of public subnets inside the vNet."
 }
 
-variable "subnet_enforce_private_link_endpoint_network_policies" {
+variable "private_endpoint_network_policies" {
   type        = string
   default     = "Disabled"
   description = "Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled. Defaults to Disabled.."

--- a/variables.tf
+++ b/variables.tf
@@ -71,9 +71,9 @@ variable "subnet_names" {
 }
 
 variable "subnet_enforce_private_link_endpoint_network_policies" {
-  type        = bool
-  default     = false
-  description = "A map with key (string) `subnet name`, value (bool) `true` or `false` to indicate enable or disable network policies for the private link endpoint on the subnet. Default value is false."
+  type        = string
+  default     = "Disabled"
+  description = "Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled. Defaults to Disabled.."
 }
 
 variable "service_endpoints" {

--- a/variables.tf
+++ b/variables.tf
@@ -156,9 +156,9 @@ variable "route_table_name" {
   description = "The name of the route table."
 }
 
-variable "disable_bgp_route_propagation" {
+variable "bgp_route_propagation_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Boolean flag which controls propagation of routes learned by BGP on that route table."
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,13 +1,13 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.6.6"
+  required_version = ">= 1.9.1"
 }
 
 terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.85.0"
+      version = ">=3.112.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 # Terraform version
 terraform {
-  required_version = ">= 1.9.1"
+  required_version = ">= 1.7.8"
 }
 
 terraform {


### PR DESCRIPTION
## what
* Change done in Attribute `private_endpoint_network_policies_enabled` in main.tf
* Change from`private_endpoint_network_policies_enabled` to  `private_endpoint_network_policies`

* the attribute `disable_bgp_route_propagation` changed to `bgp_route_propagation_enabled` for provider version `3.112`

## why
* Changes done in attribute because attribute  `private_endpoint_network_policies_enabled` and `disable_bgp_route_propagation`  has been deprecated

## references

- Link: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet