### PR TITLE
fix: Remove try function from outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,45 +1,45 @@
 output "specific_subnet_name" {
-  value       = try(azurerm_subnet.subnet[*].name, null)
+  value       = var.specific_name_subnet ? azurerm_subnet.subnet[*].name : null
   description = "The name of the subnet."
 }
 
 output "specific_subnet_id" {
-  value       = try(azurerm_subnet.subnet[*].id, null)
+  value       = var.specific_name_subnet ? azurerm_subnet.subnet[*].id : null
   description = "The name of the subnet."
 }
 
 output "specific_subnet_address_prefixes" {
-  value       = try(azurerm_subnet.subnet[*].address_prefixes, null)
+  value       = var.specific_name_subnet ? azurerm_subnet.subnet[*].address_prefixes : null
   description = "The address prefixes for the subnet."
 }
 
 output "default_subnet_name" {
-  value       = try(azurerm_subnet.subnet[*].name, null)
+  value       = !var.specific_name_subnet ? azurerm_subnet.subnet[*].name : null
   description = "The name of the subnet."
 }
 
 output "default_subnet_id" {
-  value       = try(azurerm_subnet.subnet[*].id, null)
+  value       = !var.specific_name_subnet ? azurerm_subnet.subnet[*].id : null
   description = "The subnet ID."
 }
 
 output "default_subnet_address_prefixes" {
-  value       = try(azurerm_subnet.subnet[*].address_prefixes, null)
+  value       = !var.specific_name_subnet ? azurerm_subnet.subnet[*].address_prefixes : null
   description = "The address prefixes for the subnet."
 }
 
 output "nat_gateway_id" {
-  value       = try(azurerm_nat_gateway.natgw[0].id, null)
+  value       = var.create_nat_gateway ? azurerm_nat_gateway.natgw[0].id : null
   description = "The ID of the NAT Gateway."
 }
 
 output "public_ip_address" {
-  value       = try(azurerm_public_ip.pip[0].ip_address, null)
+  value       = var.create_nat_gateway ? azurerm_public_ip.pip[0].ip_address : null
   description = "The IP address value that was allocated."
 }
 
 output "public_ip_id" {
-  value       = try(azurerm_public_ip.pip[0].id, null)
+  value       = var.create_nat_gateway ? azurerm_public_ip.pip[0].id : null
   description = " The ID of this Public IP."
 }
 


### PR DESCRIPTION
## what
* Remove `try` function from outputs.

## why
* When we have `try` function in outputs we get the following error. So to tackle that, have `try`
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/24348e07-da59-4ee6-b20b-28b15d070f9c">
